### PR TITLE
Include plugin commands and improve formatting

### DIFF
--- a/ESP_Easy__rules.xml
+++ b/ESP_Easy__rules.xml
@@ -1,8 +1,8 @@
 <NotepadPlus>
-    <UserLang name="ESP Easy rules" ext=".txt" udlVersion="2.1">
+    <UserLang name="EspEasy202113" ext=".txt" udlVersion="2.1">
         <Settings>
             <Global caseIgnored="yes" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
-            <Prefix Keywords1="yes" Keywords2="yes" Keywords3="yes" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
+            <Prefix Keywords1="yes" Keywords2="yes" Keywords3="yes" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="yes" Keywords8="yes" />
         </Settings>
         <KeywordLists>
             <Keywords name="Comments">00// 01 02 03// 04</Keywords>
@@ -13,52 +13,52 @@
             <Keywords name="Numbers, suffix1"></Keywords>
             <Keywords name="Numbers, suffix2"></Keywords>
             <Keywords name="Numbers, range"></Keywords>
-            <Keywords name="Operators1">&gt; &lt; = &lt;= &gt;= &lt;&gt; !=</Keywords>
-            <Keywords name="Operators2">#</Keywords>
-            <Keywords name="Folders in code1, open">On</Keywords>
+            <Keywords name="Operators1">&gt; &lt; = &lt;= &gt;= &lt;&gt; != + - * / % ! , #</Keywords>
+            <Keywords name="Operators2">and or</Keywords>
+            <Keywords name="Folders in code1, open">do</Keywords>
             <Keywords name="Folders in code1, middle"></Keywords>
-            <Keywords name="Folders in code1, close">EndOn</Keywords>
+            <Keywords name="Folders in code1, close">endon</Keywords>
             <Keywords name="Folders in code2, open">If</Keywords>
-            <Keywords name="Folders in code2, middle">Else</Keywords>
+            <Keywords name="Folders in code2, middle">Else ElseIf</Keywords>
             <Keywords name="Folders in code2, close">Endif</Keywords>
             <Keywords name="Folders in comment, open"></Keywords>
             <Keywords name="Folders in comment, middle"></Keywords>
             <Keywords name="Folders in comment, close"></Keywords>
-            <Keywords name="Keywords1">AccessInfo&#x000D;&#x000A;Background&#x000D;&#x000A;Build&#x000D;&#x000A;ClearAccessBlock&#x000D;&#x000A;ClearRTCram&#x000D;&#x000A;Config&#x000D;&#x000A;ControllerDisable&#x000D;&#x000A;ControllerEnable&#x000D;&#x000A;DNS&#x000D;&#x000A;DST&#x000D;&#x000A;DateTime&#x000D;&#x000A;Debug&#x000D;&#x000A;DeepSleep&#x000D;&#x000A;Delay&#x000D;&#x000A;EraseSDKwifi&#x000D;&#x000A;ExecuteRules&#x000D;&#x000A;GPIO&#x000D;&#x000A;GPIOtoggle&#x000D;&#x000A;Gateway&#x000D;&#x000A;I2Cscanner&#x000D;&#x000A;IP&#x000D;&#x000A;Let&#x000D;&#x000A;Load&#x000D;&#x000A;LogEntry&#x000D;&#x000A;LogPortStatus&#x000D;&#x000A;LongPulse&#x000D;&#x000A;LongPulse_mS&#x000D;&#x000A;LoopTimerSet&#x000D;&#x000A;LoopTimerSet_ms&#x000D;&#x000A;MCPGPIO&#x000D;&#x000A;MCPGPIOpattern&#x000D;&#x000A;MCPGPIOrange&#x000D;&#x000A;MCPGPIOtoggle&#x000D;&#x000A;MCPLongPulse&#x000D;&#x000A;MCPLongPulse_mS&#x000D;&#x000A;MCPPulse&#x000D;&#x000A;MCPmode&#x000D;&#x000A;MCPmodeRange&#x000D;&#x000A;Monitor&#x000D;&#x000A;MonitorRange&#x000D;&#x000A;Name&#x000D;&#x000A;PCFGPIO&#x000D;&#x000A;PCFGPIOpattern&#x000D;&#x000A;PCFGPIOrange&#x000D;&#x000A;PCFGPIOtoggle&#x000D;&#x000A;PCFLongPulse&#x000D;&#x000A;PCFLongPulse_mS&#x000D;&#x000A;PCFPulse&#x000D;&#x000A;PCFmode&#x000D;&#x000A;PCFmodeRange&#x000D;&#x000A;PWM&#x000D;&#x000A;Password&#x000D;&#x000A;Publish&#x000D;&#x000A;Pulse&#x000D;&#x000A;Reboot&#x000D;&#x000A;Reset&#x000D;&#x000A;ResetFlashWriteCounter&#x000D;&#x000A;Rtttl&#x000D;&#x000A;Rules&#x000D;&#x000A;Save&#x000D;&#x000A;SendTo&#x000D;&#x000A;SendToHTTP&#x000D;&#x000A;SendToUDP&#x000D;&#x000A;Servo&#x000D;&#x000A;Settings&#x000D;&#x000A;Status&#x000D;&#x000A;Subnet&#x000D;&#x000A;Subscribe&#x000D;&#x000A;TaskClear&#x000D;&#x000A;TaskClearAll&#x000D;&#x000A;TaskDisable&#x000D;&#x000A;TaskEnable&#x000D;&#x000A;TaskRun&#x000D;&#x000A;TaskValueSet&#x000D;&#x000A;TaskValueSetAndRun&#x000D;&#x000A;TimeZone&#x000D;&#x000A;TimerPause&#x000D;&#x000A;TimerResume&#x000D;&#x000A;TimerSet&#x000D;&#x000A;TimerSet_ms&#x000D;&#x000A;Tone&#x000D;&#x000A;UdpPort&#x000D;&#x000A;UdpTest&#x000D;&#x000A;UnMonitor&#x000D;&#x000A;UnMonitorRange&#x000D;&#x000A;Unit&#x000D;&#x000A;UseNTP&#x000D;&#x000A;WdConfig&#x000D;&#x000A;WdRead&#x000D;&#x000A;WifiAPKey&#x000D;&#x000A;WifiAPMode&#x000D;&#x000A;WifiAllowAP&#x000D;&#x000A;WifiConnect&#x000D;&#x000A;WifiDisconnect&#x000D;&#x000A;WifiKey&#x000D;&#x000A;WifiKey2&#x000D;&#x000A;WifiSSID&#x000D;&#x000A;WifiSSID2&#x000D;&#x000A;WifiSTAMode&#x000D;&#x000A;WifiScan&#x000D;&#x000A;meminfo&#x000D;&#x000A;meminfoDetail</Keywords>
+            <Keywords name="Keywords1">AcessInfo&#x000D;&#x000A;Background&#x000D;&#x000A;Build&#x000D;&#x000A;ClearAccessBlock&#x000D;&#x000A;ClearRTCam&#x000D;&#x000A;Config&#x000D;&#x000A;ControllerDisable&#x000D;&#x000A;ControllerEnable&#x000D;&#x000A;DateTime&#x000D;&#x000A;Debug&#x000D;&#x000A;DeepSleep&#x000D;&#x000A;Delay&#x000D;&#x000A;DNS&#x000D;&#x000A;DST&#x000D;&#x000A;EraseSDKwifi&#x000D;&#x000A;ExecuteRules&#x000D;&#x000A;Gateway&#x000D;&#x000A;I2Cscanner&#x000D;&#x000A;IP&#x000D;&#x000A;Let&#x000D;&#x000A;Load&#x000D;&#x000A;Logentry&#x000D;&#x000A;LogPortStatus&#x000D;&#x000A;LoopTimerSet&#x000D;&#x000A;LoopTimerSet_ms&#x000D;&#x000A;MemInfo&#x000D;&#x000A;MemInfoDetail&#x000D;&#x000A;Name&#x000D;&#x000A;Password&#x000D;&#x000A;Publish&#x000D;&#x000A;Reboot&#x000D;&#x000A;Reset&#x000D;&#x000A;ResetFlashWriteCounter&#x000D;&#x000A;Save&#x000D;&#x000A;SendTo&#x000D;&#x000A;SendToHTTP&#x000D;&#x000A;SendToUDP&#x000D;&#x000A;Settings&#x000D;&#x000A;Subnet&#x000D;&#x000A;Subscribe&#x000D;&#x000A;TaskClear&#x000D;&#x000A;TaskClearAll&#x000D;&#x000A;TaskDisable&#x000D;&#x000A;TaskEnable&#x000D;&#x000A;TaskRun&#x000D;&#x000A;TaskValueSet&#x000D;&#x000A;TaskValueSetAndRun&#x000D;&#x000A;TimerPause&#x000D;&#x000A;TimerResume&#x000D;&#x000A;TimerSet&#x000D;&#x000A;TimerSet_ms&#x000D;&#x000A;TimeZone&#x000D;&#x000A;UdpPort&#x000D;&#x000A;UdpTest&#x000D;&#x000A;Unit&#x000D;&#x000A;UseNTP&#x000D;&#x000A;WdConfig&#x000D;&#x000A;WdRead&#x000D;&#x000A;WifiAPkey&#x000D;&#x000A;WifiAllowAP&#x000D;&#x000A;WifiAPMode&#x000D;&#x000A;WifiConnect&#x000D;&#x000A;WifiDisconnect&#x000D;&#x000A;WifiKey&#x000D;&#x000A;WifiKey2&#x000D;&#x000A;WifiScan&#x000D;&#x000A;WifiSSID&#x000D;&#x000A;WifiSSID2&#x000D;&#x000A;WifiSTAMode</Keywords>
             <Keywords name="Keywords2">Clock#Time=&#x000D;&#x000A;GPIO#&#x000D;&#x000A;Login#Failed&#x000D;&#x000A;MQTT#Connected&#x000D;&#x000A;MQTT#Disconnected&#x000D;&#x000A;MQTTimport#Connected&#x000D;&#x000A;MQTTimport#Disconnected&#x000D;&#x000A;Rules#Timer=&#x000D;&#x000A;System#Boot&#x000D;&#x000A;System#BootMode&#x000D;&#x000A;System#Sleep&#x000D;&#x000A;System#Wake&#x000D;&#x000A;TaskExit#&#x000D;&#x000A;TaskInit#&#x000D;&#x000A;Time#Initialized&#x000D;&#x000A;Time#Set&#x000D;&#x000A;WiFi#APmodeDisabled&#x000D;&#x000A;WiFi#APmodeEnabled&#x000D;&#x000A;WiFi#ChangedAccesspoint&#x000D;&#x000A;WiFi#ChangedWiFichannel&#x000D;&#x000A;WiFi#Connected</Keywords>
-            <Keywords name="Keywords3">AsyncEvent&#x000D;&#x000A;Event</Keywords>
-            <Keywords name="Keywords4">Do</Keywords>
-            <Keywords name="Keywords5">and&#x000D;&#x000A;or</Keywords>
-            <Keywords name="Keywords6">#</Keywords>
-            <Keywords name="Keywords7"></Keywords>
-            <Keywords name="Keywords8"></Keywords>
-            <Keywords name="Delimiters">00[ 01 02] 03% 04 05% 06{ 07 08} 09( 10 11) 12 13 14 15` 16 17` 18&quot; 19 20&quot; 21&apos; 22 23&apos;</Keywords>
+            <Keywords name="Keywords3">Event&#x000D;&#x000A;AsyncEvent</Keywords>
+            <Keywords name="Keywords4">on</Keywords>
+            <Keywords name="Keywords5"></Keywords>
+            <Keywords name="Keywords6">/control?cmd=</Keywords>
+            <Keywords name="Keywords7">GPIO&#x000D;&#x000A;GPIOToggle&#x000D;&#x000A;LongPulse&#x000D;&#x000A;LongPulse_mS&#x000D;&#x000A;Monitor&#x000D;&#x000A;UnMonitor&#x000D;&#x000A;Pulse&#x000D;&#x000A;PWM&#x000D;&#x000A;Servo&#x000D;&#x000A;Status&#x000D;&#x000A;MCPGPIO&#x000D;&#x000A;MCPGPIOToggle&#x000D;&#x000A;MCPLongPulse&#x000D;&#x000A;MCPLongPulse_ms&#x000D;&#x000A;MCPPulse&#x000D;&#x000A;Status,MCP&#x000D;&#x000A;Monitor,MCP&#x000D;&#x000A;UnMonitor,MCP&#x000D;&#x000A;MonitorRange;MCP&#x000D;&#x000A;UnMonitorRange,MCP&#x000D;&#x000A;MCPGPIORange&#x000D;&#x000A;MCPGPIOPattern&#x000D;&#x000A;MCPMode&#x000D;&#x000A;MCPModeRange&#x000D;&#x000A;PCFGPIO&#x000D;&#x000A;PCFGPIOToggle&#x000D;&#x000A;PCFLongPulse&#x000D;&#x000A;PCFLongPulse_ms&#x000D;&#x000A;PCFPulse&#x000D;&#x000A;Status,PCF&#x000D;&#x000A;Monitor,PCF&#x000D;&#x000A;UnMonitor,PCF&#x000D;&#x000A;MonitorRange,PCF&#x000D;&#x000A;UnMonitorRange,PCF&#x000D;&#x000A;PCFGPIORange&#x000D;&#x000A;PCFMode&#x000D;&#x000A;Tone&#x000D;&#x000A;RTTTL&#x000D;&#x000A;&#x000D;&#x000A;&#x000D;&#x000A;&#x000D;&#x000A;</Keywords>
+            <Keywords name="Keywords8">ResetPulseCounter&#x000D;&#x000A;SetPulseCounterTotal&#x000D;&#x000A;LogPulseStatistic&#x000D;&#x000A;LCDCmd&#x000D;&#x000A;LCD&#x000D;&#x000A;OledFramedCmd&#x000D;&#x000A;OledFramedCmd,Display&#x000D;&#x000A;OledFramedCmd,Frame&#x000D;&#x000A;MotorShieldCmd,DCMotor&#x000D;&#x000A;MotorShieldCmd,Stepper&#x000D;&#x000A;Sensair_SetRelay&#x000D;&#x000A;PMSX003,Wake&#x000D;&#x000A;PMSX003,Sleep&#x000D;&#x000A;PMSX003,Reset&#x000D;&#x000A;Play&#x000D;&#x000A;Vol&#x000D;&#x000A;Eq&#x000D;&#x000A;Mode&#x000D;&#x000A;Repeat&#x000D;&#x000A;HLWCalibrate&#x000D;&#x000A;HLWReset&#x000D;&#x000A;WemosMotorShieldCMD&#x000D;&#x000A;LolinMotorShieldCMD&#x000D;&#x000A;HeatPumpir&#x000D;&#x000A;MitsubishiHP,temperature&#x000D;&#x000A;MitsubishiHP,power&#x000D;&#x000A;MitsubishiHP,mode&#x000D;&#x000A;MitsubishiHP,fan&#x000D;&#x000A;MitsubishiHP,vane&#x000D;&#x000A;MitsubishiHP,widevane&#x000D;&#x000A;Culreader_write&#x000D;&#x000A;TFTcmd&#x000D;&#x000A;TFT&#x000D;&#x000A;Touch,Rot&#x000D;&#x000A;WakeOnLan&#x000D;&#x000A;Max1704xclearalert</Keywords>
+            <Keywords name="Delimiters">00[ 01 02] 03{ 04 05} 06( 07 08) 09&apos; 10 11&apos; 12&quot; 13 14&quot; 15` 16 17` 18% 19 20% 21 22 23</Keywords>
         </KeywordLists>
         <Styles>
             <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
             <WordsStyle name="COMMENTS" fgColor="0080C0" bgColor="FFFFFF" fontStyle="0" nesting="0" />
-            <WordsStyle name="LINE COMMENTS" fgColor="0080C0" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="LINE COMMENTS" fgColor="408080" bgColor="FFFFFF" fontStyle="2" fontSize="9" nesting="0" />
             <WordsStyle name="NUMBERS" fgColor="000000" bgColor="FFFFFF" fontStyle="1" nesting="0" />
-            <WordsStyle name="KEYWORDS1" fgColor="8000FF" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="000080" bgColor="FFFFFF" fontStyle="1" nesting="0" />
             <WordsStyle name="KEYWORDS2" fgColor="FF8000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
             <WordsStyle name="KEYWORDS3" fgColor="808080" bgColor="FFFFFF" fontStyle="0" nesting="0" />
             <WordsStyle name="KEYWORDS4" fgColor="008040" bgColor="FFFFFF" fontStyle="0" nesting="0" />
-            <WordsStyle name="KEYWORDS5" fgColor="FF0000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="FF00FF" bgColor="FFFFFF" fontStyle="1" nesting="0" />
             <WordsStyle name="KEYWORDS6" fgColor="FF8000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
-            <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
-            <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="0000FF" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="0080FF" bgColor="FFFFFF" fontStyle="1" nesting="0" />
             <WordsStyle name="OPERATORS" fgColor="FF0000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
             <WordsStyle name="FOLDER IN CODE1" fgColor="008040" bgColor="FFFFFF" fontStyle="0" nesting="0" />
-            <WordsStyle name="FOLDER IN CODE2" fgColor="FF0000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
-            <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS1" fgColor="0000FF" bgColor="FFFFFF" fontStyle="0" nesting="100663296" />
-            <WordsStyle name="DELIMITERS2" fgColor="0000FF" bgColor="FFFFFF" fontStyle="0" nesting="67108864" />
-            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="15" />
-            <WordsStyle name="DELIMITERS7" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="15" />
-            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="15" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="800000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="008000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="8000FF" bgColor="FFFFFF" fontStyle="0" nesting="67" />
+            <WordsStyle name="DELIMITERS2" fgColor="0000FF" bgColor="FFFFFF" fontStyle="0" nesting="32833" />
+            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="83886151" />
+            <WordsStyle name="DELIMITERS4" fgColor="800080" bgColor="FFFFFF" fontStyle="0" nesting="71" />
+            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="71" />
+            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="71" />
+            <WordsStyle name="DELIMITERS7" fgColor="FF8000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
         </Styles>
     </UserLang>
 </NotepadPlus>


### PR DESCRIPTION
Included changes made by Patou, added the events and tweaked the nesting a bit more to allow some formatting in strings and highlight %...% along with system events.
I also added the , and the # to the list of operators, so they are clearly noticable when looking over the rules.

![image](https://user-images.githubusercontent.com/3751318/140425639-1868c29a-6b51-4b4b-bb9c-40126e9d17ec.png)
Show system events highlighted and clear difference between core commands and plugin commands

![image](https://user-images.githubusercontent.com/3751318/140425842-4f9a3f1d-36e9-498a-8ca1-fa247142201a.png)
Example of nested formatting

![image](https://user-images.githubusercontent.com/3751318/140426033-96b6ca01-522a-4d78-aee7-fa4af17e1e09.png)
Another example of nested formatting.